### PR TITLE
Add name property for gender input component

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ _A better gender form option implemeted as a react component_
 ## Usage
 
 ```html
-<GenderInput onUpdate={(val) => {}} />
+<GenderInput name='my-gender-field-name' onUpdate={(val) => {}} />
 ```
 
 ## Options
 
+- `name`: type: `string`, default: `gender-input`. Form name property used for the input
 - `required`: type `boolean`, default: `false`. Toggles `required="required" on form inputs
 - `preferNotToSay`: type `boolean`, default: `true`. Toggles an additional "Prefer not to say option"
 - `onUpdate`: type `function`. Method to call when the selected value changes. Called with one argument: the new value.

--- a/src/gender-input.tsx
+++ b/src/gender-input.tsx
@@ -4,28 +4,34 @@ import React, { Component, ChangeEvent } from 'react';
 interface GenderInputProps {
 	required?: boolean;
 	preferNotToSay?: boolean;
-	onUpdate?: (value: string) => undefined;
+	onUpdate?: (value: string) => void;
+	name?: string;
 }
 
 interface GenderInputState {
 	value: string | null;
 }
 
-export class GenderInput extends Component<GenderInputProps, GenderInputState> {
-	private choices = ['Male', 'Female', 'Non-binary', 'Other'];
+const choices = ['Male', 'Female', 'Non-binary', 'Other'];
 
+export class GenderInput extends Component<GenderInputProps, GenderInputState> {
 	static defaultProps: Partial<GenderInputProps> = {
 		required: false,
 		preferNotToSay: true,
+		name: 'gender-input',
 	};
 
 	constructor(props: GenderInputProps) {
 		super(props);
 		this.state = { value: null };
+	}
 
+	private get choices() {
 		if (this.props.preferNotToSay) {
-			this.choices.push('Prefer not to say');
+			return [...choices, 'Prefer not to say'];
 		}
+
+		return choices;
 	}
 
 	public render() {
@@ -49,6 +55,7 @@ export class GenderInput extends Component<GenderInputProps, GenderInputState> {
 		return (
 			<label key={key}>
 				<input
+					name={this.props.name}
 					type="radio"
 					checked={this.state.value === key}
 					value={key}

--- a/test/gender-input.spec.tsx
+++ b/test/gender-input.spec.tsx
@@ -35,6 +35,12 @@ describe('Gender component', () => {
 			});
 		});
 
+		it('should have name of "gender-input', () => {
+			inputs.forEach((option) => {
+				expect(option.prop('name')).to.equal('gender-input');
+			});
+		});
+
 		it('should have the correct values', () => {
 			expect(inputs.map((option) => option.prop('value'))).to.eql(defaultValues);
 		});
@@ -69,6 +75,19 @@ describe('Gender component', () => {
 
 		it('should only have the four simple choices', () => {
 			expect(labels.map((option) => option.text())).to.eql(choices);
+		});
+	});
+
+	describe('with custom name defined (name="custom-name")', () => {
+		before(() => {
+			wrapper = mount(<GenderInput name="custom-name" />);
+			inputs = wrapper.find('input');
+		});
+
+		it('should have name of "gender-input', () => {
+			inputs.forEach((option) => {
+				expect(option.prop('name')).to.equal('custom-name');
+			});
 		});
 	});
 


### PR DESCRIPTION
Fixes issue where having `[required=true]` causes all radio buttons to be required, even when one is selected.